### PR TITLE
Add gradle.properties so project builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.iml
 .gradle
 /local.properties
-/gradle.properties
 /.idea/caches
 /.idea/libraries
 /.idea/modules.xml

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
Without this change Gradle reports the following error: `org.gradle.api.GradleException: androidx.navigation.safeargs can only be used with an androidx project`